### PR TITLE
Convert to using pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,23 @@
+[build-system]
+requires = [
+    "setuptools",
+    "setuptools-scm",
+]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "testflinger-agent"
+description = "Testflinger agent"
+readme = "README.rst"
+dependencies = [
+    "PyYAML",
+    "requests",
+    "voluptuous",
+]
+dynamic = ["version"]
+
+[project.scripts]
+testflinger-agent = "testflinger_agent.cmd:main"
+
 [tool.black]
 line-length = 79

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (C) 2016-2023 Canonical
 #
 # This program is free software: you can redistribute it and/or modify

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (C) 2016-2022 Canonical
+# Copyright (C) 2016-2023 Canonical
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -18,19 +18,4 @@
 
 from setuptools import setup
 
-INSTALL_REQUIRES = [
-    "PyYAML",
-    "requests",
-    "voluptuous",
-]
-
-setup(
-    name="testflinger-agent",
-    version="1.0",
-    long_description=__doc__,
-    packages=["testflinger_agent"],
-    zip_safe=False,
-    install_requires=INSTALL_REQUIRES,
-    setup_requires=["pytest-runner"],
-    scripts=["testflinger-agent"],
-)
+setup()

--- a/testflinger_agent/__init__.py
+++ b/testflinger_agent/__init__.py
@@ -26,7 +26,7 @@ from logging.handlers import TimedRotatingFileHandler
 logger = logging.getLogger(__name__)
 
 
-def main():
+def start_agent():
     args = parse_args()
     config = load_config(args.config)
     configure_logging(config)

--- a/testflinger_agent/__init__.py
+++ b/testflinger_agent/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2016-2017 Canonical
+# Copyright (C) 2016-2023 Canonical
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/testflinger_agent/cmd.py
+++ b/testflinger_agent/cmd.py
@@ -12,19 +12,22 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Entrypoint for the testflinger-agent command"""
 
 import logging
 import sys
 
-from testflinger_agent import main
+from testflinger_agent import start_agent
 
 logger = logging.getLogger(__name__)
 
-if __name__ == "__main__":
+
+def main():
+    """main() entrypoint for the testflinger-agent command"""
     try:
-        main()
+        start_agent()
     except KeyboardInterrupt:
         logger.info("Caught interrupt, exiting!")
         sys.exit(0)
-    except Exception as e:
-        logger.exception(e)
+    except Exception as exc:  # pylint: disable=broad-except
+        logger.exception(exc)

--- a/testflinger_agent/cmd.py
+++ b/testflinger_agent/cmd.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python3
-# Copyright (C) 2016 Canonical
+# Copyright (C) 2016-2023 Canonical
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,6 @@ deps =
     requests-mock
 commands =
     {envbindir}/python setup.py develop
-    {envbindir}/python -m black --check setup.py testflinger-agent testflinger_agent
+    {envbindir}/python -m black --check setup.py testflinger_agent
     {envbindir}/python -m flake8 setup.py testflinger_agent
     {envbindir}/python -m pytest --doctest-modules --cov=testflinger_agent


### PR DESCRIPTION
This updates testflinger-agent to use the newer pyproject.toml setup methods. A minimal setup.py is preserved for backwards compatibility purposes