### PR TITLE
update flush() logic to serially empty buffer

### DIFF
--- a/testflinger_agent/__init__.py
+++ b/testflinger_agent/__init__.py
@@ -90,18 +90,17 @@ class ReqBufferHandler(logging.Handler):
 
     def flush(self):
         """Flush and post buffer"""
-        try:
-            # atomic queue iteration
-            for record in list(self.reqbuffer):
+        for record in list(self.reqbuffer):
+            try:
                 self.session.post(
                     url=self.url, json=self.format(record), timeout=5
                 )
-        except (requests.RequestException, HTTPError) as error:
-            logger.debug(error)
+            except (requests.RequestException, HTTPError) as error:
+                logger.debug(error)
 
-            return  # preserve buffer
+                return  # preserve buffer
 
-        self.reqbuffer.clear()
+            self.reqbuffer.popleft()
 
     def close(self):
         """Cleanup on handler close"""


### PR DESCRIPTION
Quick patch refactor:

The previous version of flush() cleared the buffer entirely after the try block. As the dequeue is extracted via list(), the list object under iteration will potentially be shorter than the dequeue object (if messages are appended to it during list iteration). Therefore calling dequeue.clear() at the end of the list iteration will destroy messages that haven't had a chance to be sent yet.

Now we loop over the dequeue list and send and pop in the same iteration, so the buffer is sent and cleared in a serial fashion equally. 