### PR TITLE
Improve exception handling

### DIFF
--- a/testflinger_agent/__init__.py
+++ b/testflinger_agent/__init__.py
@@ -155,7 +155,10 @@ def configure_logging(config):
     if not isinstance(log_level, int):
         log_level = logging.INFO
     logfmt = logging.Formatter(
-        fmt="[%(asctime)s] %(levelname)+7.7s: %(message)s",
+        fmt=(
+            "[%(asctime)s] %(levelname)+7.7s: "
+            "(%(filename)s:%(lineno)d)| %(message)s"
+        ),
         datefmt="%y-%m-%d %H:%M:%S",
     )
     log_path = os.path.join(


### PR DESCRIPTION
Right now, there are certain conditions (like nothing listening on the port) that will result in pagefuls of tracebacks. We are logging the full exceptions in many cases when we don't really need to be. This gives us the details we need and also adds line file:lineno information to make it even easier. Example output for when it can't connect to the server would look more like this now:
```
[23-03-02 12:15:09]   ERROR: (client.py:269)| HTTPConnectionPool(host='127.0.0.1', port=5400): Max retries exceeded with url: /v1/agents/data/rpi3bp001 (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7ff2f77c36d0>: Failed to establish a new connection: [Errno 111] Connection refused'))
[23-03-02 12:15:11]   DEBUG: (__init__.py:100)| HTTPConnectionPool(host='127.0.0.1', port=5400): Max retries exceeded with url: /v1/agents/data/rpi3bp001 (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7ff2f6e15450>: Failed to establish a new connection: [Errno 111] Connection refused'))
```

One possible downside, is that this changes the logging format for everything. So even informational messages would now have the (file:lineno) references. I don't personally have a problem with that, but curious what others think. It would look like this in the agent logs:
```
[23-03-02 12:13:57]    INFO: (__init__.py:135)| Checking jobs
[23-03-02 12:13:57]   DEBUG: (client.py:66)| Requesting a job
[23-03-02 12:13:57]    INFO: (__init__.py:137)| Sleeping for 10
```