### PR TITLE
Remove the multiprocess cancellation watcher from process_jobs

### DIFF
--- a/testflinger_agent/job.py
+++ b/testflinger_agent/job.py
@@ -16,7 +16,6 @@ import fcntl
 import json
 import logging
 import os
-import select
 import signal
 import sys
 import subprocess
@@ -82,7 +81,7 @@ class TestflingerJob:
             self._update_phase_results(
                 results_file, phase, exitcode, output_log, serial_log
             )
-        sys.exit(exitcode)
+        return exitcode
 
     def _update_phase_results(
         self, results_file, phase, exitcode, output_log, serial_log
@@ -153,7 +152,6 @@ class TestflingerJob:
         start_time = time.time()
         with open(logfile, "a", encoding="utf-8") as f:
             live_output_buffer = ""
-            readpoll = select.poll()
             buffer_timeout = time.time()
             process = subprocess.Popen(
                 cmd,
@@ -169,19 +167,21 @@ class TestflingerJob:
 
             signal.signal(signal.SIGTERM, cleanup)
             set_nonblock(process.stdout.fileno())
-            readpoll.register(process.stdout, select.POLLIN)
-            while process.poll() is None:
-                # Check if there's any new data, timeout after 10s
-                data_ready = readpoll.poll(10000)
-                if data_ready:
-                    buf = process.stdout.read().decode(
-                        sys.stdout.encoding, errors="replace"
-                    )
-                    if buf:
-                        sys.stdout.write(buf)
-                        live_output_buffer += buf
-                        f.write(buf)
-                        f.flush()
+
+            while True:
+                line = process.stdout.readline()
+                if not line and process.poll() is not None:
+                    # Process exited
+                    break
+
+                if line:
+                    # Write the latest output to the log file, stdout, and
+                    # the live output buffer
+                    buf = line.decode(sys.stdout.encoding, errors="replace")
+                    sys.stdout.write(buf)
+                    live_output_buffer += buf
+                    f.write(buf)
+                    f.flush()
                 else:
                     if (
                         self.phase == "test"
@@ -189,12 +189,22 @@ class TestflingerJob:
                     ):
                         buf = (
                             "\nERROR: Output timeout reached! "
-                            "({}s)\n".format(output_timeout)
+                            f"({output_timeout}s)\n"
                         )
                         live_output_buffer += buf
                         f.write(buf)
                         process.kill()
                         break
+
+                # Check if it's time to send the output buffer to the server
+                if live_output_buffer and time.time() - buffer_timeout > 10:
+                    if self.client.post_live_output(
+                        self.job_id, live_output_buffer
+                    ):
+                        live_output_buffer = ""
+                        buffer_timeout = time.time()
+
+                # Check global timeout
                 if (
                     self.phase != "reserve"
                     and time.time() - start_time > global_timeout
@@ -206,24 +216,19 @@ class TestflingerJob:
                     f.write(buf)
                     process.kill()
                     break
-                # Don't spam the server, only flush the buffer if there
-                # is output and it's been more than 10s
-                if live_output_buffer and time.time() - buffer_timeout > 10:
-                    buffer_timeout = time.time()
-                    # Try to stream output, if we can't connect, then
-                    # keep buffer for the next pass through this
-                    if self.client.post_live_output(
-                        self.job_id, live_output_buffer
-                    ):
-                        live_output_buffer = ""
-            buf = process.stdout.read()
-            if buf:
-                buf = buf.decode(sys.stdout.encoding, errors="replace")
-                sys.stdout.write(buf)
-                live_output_buffer += buf
-                f.write(buf)
+
+                # Check if job was canceled
+                if (
+                    self.client.check_job_state(self.job_id) == "cancelled"
+                    and self.phase != "provision"
+                ):
+                    logger.info("Job cancellation was requested, exiting.")
+                    process.kill()
+                    break
+
             if live_output_buffer:
                 self.client.post_live_output(self.job_id, live_output_buffer)
+
             try:
                 status = process.wait(10)  # process.returncode
             except TimeoutError:

--- a/testflinger_agent/tests/test_job.py
+++ b/testflinger_agent/tests/test_job.py
@@ -61,6 +61,7 @@ class TestJob:
         logfile = os.path.join(self.tmpdir, "testlog")
         fake_job_data = {"global_timeout": 1}
         requests_mock.post(rmock.ANY, status_code=200)
+        requests_mock.get(rmock.ANY, status_code=200)
         job = _TestflingerJob(fake_job_data, client)
         job.phase = "test"
         job.run_with_log("sleep 3", logfile)
@@ -75,6 +76,7 @@ class TestJob:
         self.config["global_timeout"] = 1
         fake_job_data = {"global_timeout": 3}
         requests_mock.post(rmock.ANY, status_code=200)
+        requests_mock.get(rmock.ANY, status_code=200)
         job = _TestflingerJob(fake_job_data, client)
         job.phase = "test"
         job.run_with_log("sleep 3", logfile)
@@ -88,6 +90,7 @@ class TestJob:
         logfile = os.path.join(self.tmpdir, "testlog")
         fake_job_data = {"output_timeout": 1}
         requests_mock.post(rmock.ANY, status_code=200)
+        requests_mock.get(rmock.ANY, status_code=200)
         job = _TestflingerJob(fake_job_data, client)
         job.phase = "test"
         # unfortunately, we need to sleep for longer that 10 seconds here
@@ -104,6 +107,7 @@ class TestJob:
         self.config["output_timeout"] = 1
         fake_job_data = {"output_timeout": 30}
         requests_mock.post(rmock.ANY, status_code=200)
+        requests_mock.get(rmock.ANY, status_code=200)
         job = _TestflingerJob(fake_job_data, client)
         job.phase = "test"
         # unfortunately, we need to sleep for longer that 10 seconds here
@@ -119,6 +123,7 @@ class TestJob:
         logfile = os.path.join(self.tmpdir, "testlog")
         fake_job_data = {"output_timeout": 1}
         requests_mock.post(rmock.ANY, status_code=200)
+        requests_mock.get(rmock.ANY, status_code=200)
         job = _TestflingerJob(fake_job_data, client)
         job.phase = "provision"
         # unfortunately, we need to sleep for longer that 10 seconds here


### PR DESCRIPTION
Ok, this one might look a little hairy, and there's still definitely a lot of refactoring and simplification that I'd like to do around this part, but two things that I hope set your mind at ease a bit:
1. negative diff!
2. I actually deployed this to a live agent for testing, and everything worked - provisioning, test running, reservations, etc

Previously, process_jobs() was creating a background process to watch for cancellation, while the rest of it actually got on with the business of running the test job. Looking back on it, this was really more complicated than I think it needed to be. Also, I'm trying to make it easier to modify some of this so that we can add/change things about it, so anything we can do now to work on that should pay us back in the future by making it easier and faster to make further changes.

Now, it removes that extra process for watching for cancellation and rolls the cancellation check into job.py:run_with_log(), while also organizing that a little more than it was before.
