### PR TITLE
Remove multiprocessing from testflinger agent

### DIFF
--- a/testflinger_agent/agent.py
+++ b/testflinger_agent/agent.py
@@ -14,7 +14,6 @@
 
 import json
 import logging
-import multiprocessing
 import os
 import shutil
 import time
@@ -28,39 +27,43 @@ logger = logging.getLogger(__name__)
 class TestflingerAgent:
     def __init__(self, client):
         self.client = client
-        self._state = multiprocessing.Array("c", 16)
         self.set_agent_state("waiting")
-        self.advertised_queues = self.client.config.get(
-            "advertised_queues", {}
-        )
-        self.advertised_images = self.client.config.get("advertised_images")
-        location = self.client.config.get("location", "")
-        if self.advertised_queues or location:
-            self.client.post_agent_data(
-                {"queues": self.advertised_queues, "location": location}
-            )
-        if self.advertised_queues or self.advertised_images:
-            self.status_proc = multiprocessing.Process(
-                target=self._status_worker
-            )
-            self.status_proc.daemon = True
-            self.status_proc.start()
+        self._post_initial_agent_data()
 
-    def _status_worker(self):
-        # Report advertised queues to testflinger server when we are listening
-        while True:
-            # Post every 2min unless the agent is offline
-            if self._state.value.decode("utf-8") != "offline":
-                if self.advertised_queues:
-                    self.client.post_queues(self.advertised_queues)
-                if self.advertised_images:
-                    self.client.post_images(self.advertised_images)
-            time.sleep(120)
+    def _post_initial_agent_data(self):
+        """Post the initial agent data to the server once on agent startup"""
+
+        location = self.client.config.get("location", "")
+        advertised_queues = self._post_advertised_queues()
+        self._post_advertised_images()
+
+        if advertised_queues or location:
+            self.client.post_agent_data(
+                {"queues": advertised_queues, "location": location}
+            )
+
+    def _post_advertised_queues(self):
+        """
+        Get the advertised queues from the config and send them to the server
+
+        :return: Dictionary of advertised queues
+        """
+        advertised_queues = self.client.config.get("advertised_queues", {})
+        if advertised_queues:
+            self.client.post_queues(advertised_queues)
+        return advertised_queues
+
+    def _post_advertised_images(self):
+        """
+        Get the advertised images from the config and post them to the server
+        """
+        advertised_images = self.client.config.get("advertised_images")
+        if advertised_images:
+            self.client.post_images(advertised_images)
 
     def set_agent_state(self, state):
         """Send the agent state to the server"""
         self.client.post_agent_data({"state": state})
-        self._state.value = state.encode("utf-8")
 
     def get_offline_files(self):
         # Return possible restart filenames with and without dashes

--- a/testflinger_agent/job.py
+++ b/testflinger_agent/job.py
@@ -16,7 +16,6 @@ import fcntl
 import json
 import logging
 import os
-import select
 import signal
 import sys
 import subprocess
@@ -88,7 +87,7 @@ class TestflingerJob:
             )
         if phase == "allocate":
             self.allocate_phase(rundir)
-        sys.exit(exitcode)
+        return exitcode
 
     def _update_phase_results(
         self, results_file, phase, exitcode, output_log, serial_log
@@ -201,7 +200,6 @@ class TestflingerJob:
         start_time = time.time()
         with open(logfile, "a", encoding="utf-8") as f:
             live_output_buffer = ""
-            readpoll = select.poll()
             buffer_timeout = time.time()
             process = subprocess.Popen(
                 cmd,
@@ -217,19 +215,21 @@ class TestflingerJob:
 
             signal.signal(signal.SIGTERM, cleanup)
             set_nonblock(process.stdout.fileno())
-            readpoll.register(process.stdout, select.POLLIN)
-            while process.poll() is None:
-                # Check if there's any new data, timeout after 10s
-                data_ready = readpoll.poll(10000)
-                if data_ready:
-                    buf = process.stdout.read().decode(
-                        sys.stdout.encoding, errors="replace"
-                    )
-                    if buf:
-                        sys.stdout.write(buf)
-                        live_output_buffer += buf
-                        f.write(buf)
-                        f.flush()
+
+            while True:
+                line = process.stdout.readline()
+                if not line and process.poll() is not None:
+                    # Process exited
+                    break
+
+                if line:
+                    # Write the latest output to the log file, stdout, and
+                    # the live output buffer
+                    buf = line.decode(sys.stdout.encoding, errors="replace")
+                    sys.stdout.write(buf)
+                    live_output_buffer += buf
+                    f.write(buf)
+                    f.flush()
                 else:
                     if (
                         self.phase == "test"
@@ -243,6 +243,16 @@ class TestflingerJob:
                         f.write(buf)
                         process.kill()
                         break
+
+                # Check if it's time to send the output buffer to the server
+                if live_output_buffer and time.time() - buffer_timeout > 10:
+                    if self.client.post_live_output(
+                        self.job_id, live_output_buffer
+                    ):
+                        live_output_buffer = ""
+                        buffer_timeout = time.time()
+
+                # Check global timeout
                 if (
                     self.phase != "reserve"
                     and time.time() - start_time > global_timeout
@@ -254,24 +264,19 @@ class TestflingerJob:
                     f.write(buf)
                     process.kill()
                     break
-                # Don't spam the server, only flush the buffer if there
-                # is output and it's been more than 10s
-                if live_output_buffer and time.time() - buffer_timeout > 10:
-                    buffer_timeout = time.time()
-                    # Try to stream output, if we can't connect, then
-                    # keep buffer for the next pass through this
-                    if self.client.post_live_output(
-                        self.job_id, live_output_buffer
-                    ):
-                        live_output_buffer = ""
-            buf = process.stdout.read()
-            if buf:
-                buf = buf.decode(sys.stdout.encoding, errors="replace")
-                sys.stdout.write(buf)
-                live_output_buffer += buf
-                f.write(buf)
+
+                # Check if job was canceled
+                if (
+                    self.client.check_job_state(self.job_id) == "cancelled"
+                    and self.phase != "provision"
+                ):
+                    logger.info("Job cancellation was requested, exiting.")
+                    process.kill()
+                    break
+
             if live_output_buffer:
                 self.client.post_live_output(self.job_id, live_output_buffer)
+
             try:
                 status = process.wait(10)  # process.returncode
             except TimeoutError:

--- a/testflinger_agent/job.py
+++ b/testflinger_agent/job.py
@@ -217,7 +217,7 @@ class TestflingerJob:
             set_nonblock(process.stdout.fileno())
 
             while True:
-                line = process.stdout.readline()
+                line = process.stdout.read()
                 if not line and process.poll() is not None:
                     # Process exited
                     break

--- a/testflinger_agent/tests/test_job.py
+++ b/testflinger_agent/tests/test_job.py
@@ -61,6 +61,7 @@ class TestJob:
         logfile = os.path.join(self.tmpdir, "testlog")
         fake_job_data = {"global_timeout": 1}
         requests_mock.post(rmock.ANY, status_code=200)
+        requests_mock.get(rmock.ANY, status_code=200)
         job = _TestflingerJob(fake_job_data, client)
         job.phase = "test"
         job.run_with_log("sleep 3", logfile)
@@ -75,6 +76,7 @@ class TestJob:
         self.config["global_timeout"] = 1
         fake_job_data = {"global_timeout": 3}
         requests_mock.post(rmock.ANY, status_code=200)
+        requests_mock.get(rmock.ANY, status_code=200)
         job = _TestflingerJob(fake_job_data, client)
         job.phase = "test"
         job.run_with_log("sleep 3", logfile)
@@ -88,6 +90,7 @@ class TestJob:
         logfile = os.path.join(self.tmpdir, "testlog")
         fake_job_data = {"output_timeout": 1}
         requests_mock.post(rmock.ANY, status_code=200)
+        requests_mock.get(rmock.ANY, status_code=200)
         job = _TestflingerJob(fake_job_data, client)
         job.phase = "test"
         # unfortunately, we need to sleep for longer that 10 seconds here
@@ -104,6 +107,7 @@ class TestJob:
         self.config["output_timeout"] = 1
         fake_job_data = {"output_timeout": 30}
         requests_mock.post(rmock.ANY, status_code=200)
+        requests_mock.get(rmock.ANY, status_code=200)
         job = _TestflingerJob(fake_job_data, client)
         job.phase = "test"
         # unfortunately, we need to sleep for longer that 10 seconds here
@@ -119,6 +123,7 @@ class TestJob:
         logfile = os.path.join(self.tmpdir, "testlog")
         fake_job_data = {"output_timeout": 1}
         requests_mock.post(rmock.ANY, status_code=200)
+        requests_mock.get(rmock.ANY, status_code=200)
         job = _TestflingerJob(fake_job_data, client)
         job.phase = "provision"
         # unfortunately, we need to sleep for longer that 10 seconds here


### PR DESCRIPTION
This completely eliminates the need for multiprocessing. There are a few steps that don't really need to happen throughout the entire lifecycle of the agent like pushing the advertised queues and images, so we move that to just happen at the beginning. Next, refactor the agent code for processing the test phases so that it no longer needs a second process to watch for cancellation.

The end result is conceptually much simpler, and I think sets the groundwork for more simplification and easier modification of this code.

I tested this by pushing the new agent code to dragonboard006 then running several different tests against it:
1. provision, then run some simple commands during the test phase
2. skip provisioning, run commands that generate LOTS of output (timestamped) very quickly - this previously caused some issues when I tried to rework this section before, but I figured out why and output doesn't stall now
3. slow output during test phase, ensure cancellation works properly
4. reservation

I didn't find any changes in behaviour from the original agent.