### PR TITLE
Fix state to be complete rather than completed for consistency

### DIFF
--- a/testflinger_agent/job.py
+++ b/testflinger_agent/job.py
@@ -145,17 +145,18 @@ class TestflingerJob:
 
     def wait_for_completion(self):
         """Monitor the parent job and exit when it completes"""
-        # For now, we don't have to monitor our own job state, since the
-        # another thread monitors it. But if this changes, we'll need to watch
-        # for changes to our own job state
 
         while True:
             try:
                 parent_job_state = self.client.check_job_state(
                     self.job_data.get("parent_job_id")
                 )
-                if parent_job_state in ("completed", "cancelled"):
+                if parent_job_state in ("complete", "cancelled"):
                     logger.info("Parent job completed, exiting...")
+                    break
+                this_job_state = self.client.check_job_state(self.job_id)
+                if this_job_state in ("complete", "cancelled"):
+                    logger.info("This job completed, exiting...")
                     break
             except TFServerError:
                 logger.warning("Failed to get parent job, retrying...")

--- a/testflinger_agent/job.py
+++ b/testflinger_agent/job.py
@@ -151,11 +151,11 @@ class TestflingerJob:
                 parent_job_state = self.client.check_job_state(
                     self.job_data.get("parent_job_id")
                 )
-                if parent_job_state in ("complete", "cancelled"):
+                if parent_job_state in ("complete", "completed", "cancelled"):
                     logger.info("Parent job completed, exiting...")
                     break
                 this_job_state = self.client.check_job_state(self.job_id)
-                if this_job_state in ("complete", "cancelled"):
+                if this_job_state in ("complete", "completed", "cancelled"):
                     logger.info("This job completed, exiting...")
                     break
             except TFServerError:

--- a/testflinger_agent/tests/test_job.py
+++ b/testflinger_agent/tests/test_job.py
@@ -156,8 +156,8 @@ class TestJob:
     def test_wait_for_completion(self, client):
         """Test that wait_for_completion works"""
 
-        # Make sure we return "complete" for the parent job state
-        client.check_job_state = lambda _: "complete"
+        # Make sure we return "completed" for the parent job state
+        client.check_job_state = lambda _: "completed"
 
         job = _TestflingerJob({"parent_job_id": "999"}, client)
         job.wait_for_completion()

--- a/testflinger_agent/tests/test_job.py
+++ b/testflinger_agent/tests/test_job.py
@@ -156,8 +156,8 @@ class TestJob:
     def test_wait_for_completion(self, client):
         """Test that wait_for_completion works"""
 
-        # Make sure we return "completed" for the parent job state
-        client.check_job_state = lambda _: "completed"
+        # Make sure we return "complete" for the parent job state
+        client.check_job_state = lambda _: "complete"
 
         job = _TestflingerJob({"parent_job_id": "999"}, client)
         job.wait_for_completion()


### PR DESCRIPTION
ideally this would be an enum or something, but there's not a good shared understanding of what that would map to across all testflinger tools right now, so they expect strings at the moment.