### PR TITLE
If parent job doesn't exist, don't poll the state during allocate

### DIFF
--- a/testflinger_agent/job.py
+++ b/testflinger_agent/job.py
@@ -148,18 +148,23 @@ class TestflingerJob:
 
         while True:
             try:
+                this_job_state = self.client.check_job_state(self.job_id)
+                if this_job_state in ("complete", "completed", "cancelled"):
+                    logger.info("This job completed, exiting...")
+                    break
+
+                parent_job_id = self.job_data.get("parent_job_id")
+                if not parent_job_id:
+                    logger.warning("No parent job ID found while allocated")
+                    continue
                 parent_job_state = self.client.check_job_state(
                     self.job_data.get("parent_job_id")
                 )
                 if parent_job_state in ("complete", "completed", "cancelled"):
                     logger.info("Parent job completed, exiting...")
                     break
-                this_job_state = self.client.check_job_state(self.job_id)
-                if this_job_state in ("complete", "completed", "cancelled"):
-                    logger.info("This job completed, exiting...")
-                    break
             except TFServerError:
-                logger.warning("Failed to get parent job, retrying...")
+                logger.warning("Failed to get allocated job status, retrying")
             time.sleep(60)
 
     def _set_truncate(self, f, size=1024 * 1024):


### PR DESCRIPTION
This can result in a lot of 404s for some experiments happening now with using allocated state for something like a reservation, such as spread, where we force devices into this state to have control. Since these aren't really multi-device jobs though, they have no parent job id, which makes this do an unnecessary check of the job state with a missing job id, and results in a 404. Not a critical problem, but it spams the logs a bit.