### PR TITLE
Add firmware_update phase

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -101,6 +101,10 @@ The following configuration options are supported:
 
   - Command to run for the provision phase
 
+- **firmware_update_command**:
+
+  - Command to run for the firmware_update phase
+
 - **allocate_command**:
 
   - Command to run for the allocate phase
@@ -140,6 +144,13 @@ The following test phases are currently supported:
     device by installing (if possible) the image requested in the test job.
     If the provision_data section is missing from the job, this phase will
     not run.
+
+- **firmware_update**:
+
+  - This phase is run after the provision phase, and is used to perform 
+    firmware update on the device (if applicable) with the given version in
+    the test job. If the firmware_update_data section is missing from the
+    job, this phase will not run.
 
 - **test**:
   

--- a/testflinger_agent/agent.py
+++ b/testflinger_agent/agent.py
@@ -123,7 +123,14 @@ class TestflingerAgent:
 
     def process_jobs(self):
         """Coordinate checking for new jobs and handling them if they exists"""
-        TEST_PHASES = ["setup", "provision", "test", "allocate", "reserve"]
+        TEST_PHASES = [
+            "setup",
+            "provision",
+            "firmware_update",
+            "test",
+            "allocate",
+            "reserve",
+        ]
 
         # First, see if we have any old results that we couldn't send last time
         self.retry_old_results()

--- a/testflinger_agent/job.py
+++ b/testflinger_agent/job.py
@@ -59,6 +59,13 @@ class TestflingerJob:
         if phase == "provision" and not self.job_data.get("provision_data"):
             logger.info("No provision_data defined in job data, skipping...")
             return 0
+        if phase == "firmware_update" and not self.job_data.get(
+            "firmware_update_data"
+        ):
+            logger.info(
+                "No firmware_update_data defined in job data, skipping..."
+            )
+            return 0
         if phase == "test" and not self.job_data.get("test_data"):
             logger.info("No test_data defined in job data, skipping...")
             return 0

--- a/testflinger_agent/schema.py
+++ b/testflinger_agent/schema.py
@@ -33,6 +33,7 @@ SCHEMA_V1 = {
     voluptuous.Required("job_queues"): list,
     voluptuous.Required("setup_command", default=""): str,
     voluptuous.Required("provision_command", default=""): str,
+    voluptuous.Required("firmware_update_command", default=""): str,
     voluptuous.Required("test_command", default=""): str,
     voluptuous.Required("allocate_command", default=""): str,
     voluptuous.Required("reserve_command", default=""): str,


### PR DESCRIPTION
## Description
<!--
Describe your changes here:
- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

Base on [CR033 - Firmware updates for regression testing](https://docs.google.com/document/d/1yMYK5IUFyhb8Y5-pbxOjBekvRkasbUjee7Nw1ySkA5g), introduce a new optional phase **firmware_update** after provision phase to handle request for firmware update on the device. As in the spec, this new phase is implemented in `DefaultDevice`, so it won't need any change on existing `DeviceConnector` codes.

To trigger **firmware_update** phase, the following section needs to be provided in job.yaml. If the `firmware_update_data` section is missing from the job, this phase will not run. 
```
firmware_update_data:
  version: < latest >
  ignore_failure: < false | true >
```
Variables in `firmware_update_data`:
- `version`: The desired firmware level on the device. Currently it only supports `latest` (upgrading all components in the device with the latest firmware release). More options are planned to be implemented in the future once we gathering data for working firmware baseline on devices.
- `ignore_failure`: When set to `false`, **Testflinger Agent** will suspend the job if **firmware_update** phase return a status other than 0, which implies there's a failure during firmware_update phase. If set to `true`, the job will continue regardless the status of **firmware_update** phase.

### Code changes
Add **firmware_update** phase in job.py and agent.py.
Update schema.py to handle the phase with `firmware_update_command`.
> [!IMPORTANT]
> For each Testflinger agent instance, `firmware_update_command` needs to be specified in testflinger-agent.conf, giving `firmware_update` as its phase name.

In order to make it work as a whole, there're also PRs raised in [testflinger](https://github.com/canonical/testflinger/pull/114) and [snappy-device-agents](https://github.com/canonical/snappy-device-agents/pull/91).


## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->
 N/A
## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->
README.rst is updated for the new phase.


## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run.
-->
It's tested by building a [dev testflinger server](https://github.com/canonical/testflinger/pull/114) with [docker](https://github.com/canonical/testflinger/blob/main/HACKING.md#docker) along with modified testflinger-agent and snappy-device-agents.

- [x] Unit tests
```
(env) ubuntu@juju-ee0bf9-0:/srv/testflinger-agent/dell-optiplex3070-c26629/testflinger-agent$ sudo  /srv/testflinger-agent/dell-optiplex3070-c26629/env/bin/python3 -m coverage run -m pytest .
============================================== test session starts ==============================================
platform linux -- Python 3.8.10, pytest-7.4.2, pluggy-1.3.0
rootdir: /srv/testflinger-agent/dell-optiplex3070-c26629/testflinger-agent
plugins: requests-mock-1.11.0
collected 20 items                                                                                              

testflinger_agent/tests/test_agent.py 
.......                                                             [ 35%]
testflinger_agent/tests/test_client.py ..                                                                 [ 45%]
testflinger_agent/tests/test_config.py ..                                                                 [ 55%]
testflinger_agent/tests/test_job.py .........                                                             [100%]

=============================================== warnings summary ================================================
testflinger_agent/tests/test_job.py:155
  /srv/testflinger-agent/dell-optiplex3070-c26629/testflinger-agent/testflinger_agent/tests/test_job.py:155: PytestUnknownMarkWarning: Unknown pytest.mark.timeout - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.timeout(1)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=================================== 20 passed, 1 warning in 80.27s (0:01:20) ====================================

````
- [x] Testflinger Server is able to accept job.yaml with `firmware_update_data` section and assign to Testflinger Agents
- [x] Testflinger Agent is able to work with Testflinger Device Connector (tested with noprovision) to run **firmware_update** phase